### PR TITLE
fix: Registration requiring username but no input is showing

### DIFF
--- a/app/Http/Livewire/App/Register.php
+++ b/app/Http/Livewire/App/Register.php
@@ -49,13 +49,12 @@ class Register extends Component
     {
         $this->validate();
 
-        $user = \App\Models\User::create();
-        $user->name = $this->credentials['name'];
-        $user->username = $this->credentials['username'];
-        $user->password = $this->credentials['password'];
-        $user->email = $this->credentials['email'];
-
-        $user->save();
+        $user = \App\Models\User::create([
+            'name' => $this->credentials['name'],
+            'username' => $this->credentials['username'],
+            'password' => $this->credentials['password'],
+            'email' => $this->credentials['email'],
+        ]);
 
         Auth::loginUsingId($user->id);
 

--- a/app/Http/Livewire/App/Register.php
+++ b/app/Http/Livewire/App/Register.php
@@ -21,7 +21,7 @@ class Register extends Component
         return [
             'credentials.name' => ['required', 'string'],
             'credentials.email' => ['required', 'email', 'unique:users,email'],
-            'credentials.username' => ['required', 'email', 'unique:users,username'],
+            'credentials.username' => ['required', 'unique:users,username'],
             'credentials.password' => [
                 'required',
                 'confirmed',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
+        'username',
         'name',
         'email',
         'password',

--- a/resources/views/livewire/app/register.blade.php
+++ b/resources/views/livewire/app/register.blade.php
@@ -17,6 +17,10 @@
                                 wire:model="credentials.name" autofocus>
                         </fieldset>
                         <fieldset class="form-group">
+                            <input class="form-control form-control-lg" type="text" placeholder="Your User Name"
+                                wire:model="credentials.username" autofocus>
+                        </fieldset>
+                        <fieldset class="form-group">
                             <input class="form-control form-control-lg" type="email" placeholder="Email"
                                 wire:model='credentials.email'>
                         </fieldset>


### PR DESCRIPTION
## Description

This fixes a problem when I try to create an user. It complains I haven't filled the "username" field but there is no input in the page for me to fill.
Also fixes it creating a User entry on database before filling it with user input values which in turn produces a NOT NULL error on database because it tries to save the user entry with only created_at and updated_at.

## Evidence

Even on live demo at https://realworld-tall-app.fly.dev it can be observed:
![image](https://github.com/user-attachments/assets/6716f92a-70ee-43c0-84f4-0bf6c8f43b8b)
